### PR TITLE
Support CUDA 12 and NVIDIA Blackwell GPUs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,10 @@ The current library is still a work-in-progress. It is fully functional but docu
 </p>
 
 ## Dependencies
-u-Segment3D has a number of dependencies detailed in the requirements.txt. GPU dependencies are based on installing Cellpose to use as the default 2D segmentation method in u-Segment3D. 
+u-Segment3D has a number of dependencies detailed in `pyproject.toml`. GPU
+dependencies are based on installing Cellpose to use as the default 2D
+segmentation method in u-Segment3D. NVIDIA GPU installations use the CUDA 12
+CuPy package (`cupy-cuda12x`). Install only one CuPy package in an environment.
 
 
 ## Installation
@@ -67,14 +70,22 @@ pip install u-Segment3D
 u-Segment3D can also be installed by git cloning the repository and running pip in the cloned folder with python 3.9-3.12. We have developed on Python==3.9 on Red Hat Enterprise Linux Server 7.9. `pyproject.toml` configures the individual dependencies for each OS.
 
 ### Linux
-We suggest first creating a new conda environment for install and use conda to install cudatoolkit and cudnn first: 
+We suggest first creating a new conda environment for installation. Choose a
+PyTorch build supported by both the installed NVIDIA driver and the target GPU.
+For example, a CUDA 12.6 PyTorch build supports older Pascal GPUs, while newer
+builds can be used for Ampere and Blackwell GPUs:
 ```
-conda create -n u_Segment3D_env python=3.9 cudatoolkit=11.8.* cudnn==8.* -c anaconda
+conda create -n u_Segment3D_env python=3.9
 conda install -n u_Segment3D_env -c conda-forge scikit-fmm
 conda activate u_Segment3D_env
+pip install torch --index-url https://download.pytorch.org/whl/cu126
 pip install .
 ```
-If on a HPC cluster, depending on the way it is setup, you may need to module load the cuda corresponding to the install, `module load cuda118/toolkit/11.8.0` prior to activating the conda environment to use the installed `cupy` library functions for image resizing. Otherwise, u-Segment3D will fall back to a `pytorch` version of image resizing. Don't worry, this still uses gpu, but is slower than using cupy.
+On an HPC cluster, load a CUDA 12 toolkit compatible with the installed driver
+before activating the environment so that CuPy can provide GPU image resizing.
+Blackwell GPUs require CUDA 12.8 or newer for native support. If CuPy cannot use
+CUDA, u-Segment3D falls back to its PyTorch implementation of image resizing;
+this still uses the GPU when PyTorch CUDA is available, but it is slower.
 
 **Errors we have encountered:**
 
@@ -90,8 +101,9 @@ conda install -n u_Segment3D_env pyicu -c conda-forge # tries to install a preco
 
 ### Windows
 ```
-conda create -n u_Segment3D_env python=3.9 cudatoolkit=11.8.* cudnn==8.* -c anaconda
+conda create -n u_Segment3D_env python=3.9
 conda activate u_Segment3D_env
+pip install torch --index-url https://download.pytorch.org/whl/cu126
 pip install .
 ```
 On machine with NVIDIA graphics card, check to see if torch has been correctly installed with GPU by importing the library in Python. 
@@ -99,15 +111,16 @@ On machine with NVIDIA graphics card, check to see if torch has been correctly i
 import torch
 print(torch.cuda.is_available())
 ```
-If `True`, nothing needs to be done, you are set. If `False`, you need to install an earlier version of pytorch compiled for cuda11.8
+If `True`, nothing needs to be done. If `False`, install a PyTorch build that
+matches the supported CUDA version for the target GPU and driver, for example:
 ```
-pip install torch==2.0.1 --index-url https://download.pytorch.org/whl/cu118
+pip install torch --index-url https://download.pytorch.org/whl/cu126
 ```
 See https://pytorch.org/get-started/previous-versions/ to check out other pytorch versions.
 
 Alternatively, you may try to install pytorch through anaconda from the conda-forge channel:
 ```
-conda install pytorch torchvision torchaudio pytorch-cuda=11.8 -c pytorch -c nvidia
+conda install pytorch torchvision torchaudio pytorch-cuda=12.6 -c pytorch -c nvidia
 ```
 
 **Errors we have encountered:**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     'numpy<2.0',   
     'pyarrow<21',
     'cellpose<4.0',
-    'cupy-cuda11x; sys_platform!="darwin"',
+    'cupy-cuda12x; sys_platform!="darwin"',
     'dask[complete]',
     'scikit-image',
     'scikit-learn',
@@ -61,4 +61,3 @@ dependencies = [
 [project.urls]
 Homepage = "https://github.com/DanuserLab/u-segment3D"
 Issues = "https://github.com/DanuserLab/u-segment3D/issues"
-


### PR DESCRIPTION
## Summary

Replace the non-macOS `cupy-cuda11x` dependency with `cupy-cuda12x` and update the installation guidance for CUDA 12 GPU runtimes.

This is needed for NVIDIA Blackwell devices. In our production integration, the CUDA 11 CuPy wheel failed immediately on an RTX PRO 6000 Blackwell with `CUDA_ERROR_NO_BINARY_FOR_GPU`. The same u-Segment3D workflow ran successfully after changing only the CuPy distribution to `cupy-cuda12x`.

The documentation also keeps an explicit CUDA 12.6 PyTorch path for Pascal GPUs such as the P40. Newer PyTorch/CUDA builds can be used for Ampere and Blackwell, but the P40 requires a build that still contains Pascal kernels.

## Quantitative validation

We tested one real microscopy field with shape `9 x 2000 x 2000 x 4`, using the same cyto3 weights, u-Segment3D configuration, image bytes, and segmentation parameters across runs.

| GPU | CuPy package | PyTorch CUDA build | Labels | Foreground voxels | Runtime |
|---|---|---:|---:|---:|---:|
| A100 | `cupy-cuda11x==13.6.0` | cu130 | 309 | 3,334,997 | 514 s |
| A100 | `cupy-cuda12x==13.6.0` | cu130 | 309 | 3,334,997 | 513 s |
| RTX PRO 6000 Blackwell | `cupy-cuda12x==13.6.0` | cu130 | 304 | 3,338,014 | 356 s |
| A100 | `cupy-cuda12x==13.6.0` | cu126 | 305 | 3,335,662 | 498 s |
| P40 | `cupy-cuda12x==13.6.0` | cu126 | 307 | 3,337,938 | 474 s |

The A100 CUDA-11 and CUDA-12 outputs were byte-identical, including the label-array SHA-256:

`25a89a...`

Cross-architecture comparisons were also highly concordant:

| Comparison | Dice | IoU | Boundary F1 | ARI |
|---|---:|---:|---:|---:|
| A100 cu130 vs Blackwell cu130 | 0.999433 | 0.998867 | 0.997581 | 0.999308 |
| A100 cu130 vs A100 cu126 | 0.999724 | 0.999448 | 0.999212 | 0.999677 |
| A100 cu126 vs P40 cu126 | 0.999547 | 0.999094 | 0.997855 | 0.999449 |
| Blackwell cu130 vs P40 cu126 | 0.999580 | 0.999161 | 0.999305 | 0.999555 |

Instance counts differ slightly across GPU architectures and PyTorch builds, so we do not claim byte-identical cross-device output. However, foreground and instance-label agreement are above 0.997 on every reported metric. The A100 serves as a bridge showing that the CuPy CUDA-11 to CUDA-12 dependency change itself is byte-identical under the same PyTorch build.

## Changes

- Use `cupy-cuda12x` on non-macOS platforms.
- Explain that only one CuPy distribution should be installed in an environment.
- Update Linux and Windows examples to CUDA 12-compatible PyTorch installation commands.
- Document that Blackwell needs CUDA 12.8 or newer and that CUDA 12.6 remains useful for Pascal compatibility.

## Verification

Built the wheel from this branch and inspected its generated `METADATA`:

```text
Requires-Dist: cupy-cuda12x; sys_platform != "darwin"
```

No CUDA-11 CuPy dependency remains in the built package metadata.